### PR TITLE
Ensure volume returns zero if sound is unassigned.

### DIFF
--- a/src/main/java/org/orecruncher/dsurround/sound/BackgroundSoundLoop.java
+++ b/src/main/java/org/orecruncher/dsurround/sound/BackgroundSoundLoop.java
@@ -72,7 +72,12 @@ public class BackgroundSoundLoop extends AbstractTickableSoundInstance {
 
     @Override
     public float getVolume() {
-        return super.getVolume() * this.scale;
+        // Possible that the sound was not yet assigned.  Seen issues when exiting worlds.
+        if (this.sound != null) {
+            return super.getVolume() * this.scale;
+        } else {
+            return 0F;
+        }
     }
 
     public void setScaleTarget(float target) {


### PR DESCRIPTION
Added a check to return zero when the sound is null.

[crash-2024-12-04_19.54.19-client.txt](https://github.com/user-attachments/files/18016066/crash-2024-12-04_19.54.19-client.txt)
